### PR TITLE
Fix Shorts JSON key

### DIFF
--- a/scrapetube/scrapetube.py
+++ b/scrapetube/scrapetube.py
@@ -8,7 +8,7 @@ from typing_extensions import Literal
 type_property_map = {
     "videos": "videoRenderer",
     "streams": "videoRenderer",
-    "shorts": "reelItemRenderer"
+    "shorts": "reelWatchEndpoint"
 }
 
 def get_channel(


### PR DESCRIPTION
YouTube has updated the way Shorts are represented in their API response. The new key is `reelWatchEndpoint` instead of `reelItemRenderer`.